### PR TITLE
Adding NonInteractive to Fix Tz Config Hang

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -6,6 +6,7 @@ ENV HOST=0.0.0.0
 ENV PORT=9001
 ENV application_directory=/home/node/app
 ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Create app directory
 WORKDIR $application_directory

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu:18.04
 ENV HOST=0.0.0.0
 ENV PORT=9001
 ENV application_directory=/home/node/app
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Create app directory
 WORKDIR $application_directory

--- a/master/scheduler/Dockerfile
+++ b/master/scheduler/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:18.04
 
 # Application parameters and variables
 ENV application_directory=/home/node/scheduler
+ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Create app directory
 WORKDIR $application_directory


### PR DESCRIPTION
The TZ Data setup stops the docker build midway with no way to go forward . This fixes that by making Debian Non Interactive.

Ref Stackoverflow: https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai